### PR TITLE
ci: update upload-artifact action from v3 to v4

### DIFF
--- a/.github/workflows/firebase_distribution.yml
+++ b/.github/workflows/firebase_distribution.yml
@@ -104,7 +104,7 @@ jobs:
           EOF
 
       - name: 📤 Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-assets
           path: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use the latest version of the `upload-artifact` action.

* [`.github/workflows/firebase_distribution.yml`](diffhunk://#diff-444bd40a4fe3edd84d9fa01f3e85fa4723c34acdb2c632639854cdfdebb64cc2L107-R107): Updated the `actions/upload-artifact` action from version `v3` to `v4` in the "📤 Upload Artifacts" step.