### PR TITLE
ci(firebase): add fastlane plugins installation step

### DIFF
--- a/.github/workflows/firebase_distribution.yml
+++ b/.github/workflows/firebase_distribution.yml
@@ -58,6 +58,11 @@ jobs:
           cd android
           bundle install
 
+      - name: 🧩 Install Fastlane Plugins
+        run: |
+          cd android
+          bundle exec fastlane install_plugins
+
       - name: 🚀 Firebase Distribution via Fastlane
         run: |
           cd android

--- a/android/Gemfile.lock
+++ b/android/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
     fastlane-plugin-firebase_app_distribution (0.10.1)
       google-apis-firebaseappdistribution_v1 (~> 0.3.0)
       google-apis-firebaseappdistribution_v1alpha (~> 0.2.0)
+    fastlane-plugin-sentry (1.30.0)
+      os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)
     gh_inspector (1.1.3)
@@ -230,6 +232,7 @@ DEPENDENCIES
   dotenv
   fastlane
   fastlane-plugin-firebase_app_distribution
+  fastlane-plugin-sentry
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
This pull request updates the Firebase distribution workflow to include a step for installing Fastlane plugins before running the distribution process.

Workflow enhancement:

* [`.github/workflows/firebase_distribution.yml`](diffhunk://#diff-444bd40a4fe3edd84d9fa01f3e85fa4723c34acdb2c632639854cdfdebb64cc2R61-R65): Added a new step to install Fastlane plugins (`fastlane install_plugins`) in the Firebase distribution workflow. This ensures that all required plugins are available before the distribution step. The workflow now installs required fastlane plugins, including the Sentry plugin, before distribution. This ensures all dependencies are properly set up for the deployment process.