### PR TITLE
build(fastlane): add sentry plugin to android fastlane configuration

### DIFF
--- a/android/Gemfile
+++ b/android/Gemfile
@@ -2,6 +2,8 @@ source "https://rubygems.org"
 
 gem "fastlane"
 gem 'dotenv'
+# android/Gemfile
+gem 'fastlane-plugin-sentry'
 
 plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
 eval_gemfile(plugins_path) if File.exist?(plugins_path)

--- a/android/fastlane/Pluginfile
+++ b/android/fastlane/Pluginfile
@@ -3,3 +3,5 @@
 # Ensure this file is checked in to source control!
 
 gem 'fastlane-plugin-firebase_app_distribution'
+# android/Pluginfile
+gem 'fastlane-plugin-sentry'


### PR DESCRIPTION
This pull request introduces a new dependency, `fastlane-plugin-sentry`, to the Android project by updating the `Gemfile` and `Pluginfile`. This plugin will likely be used for integrating Sentry error tracking into the Fastlane workflows.

Dependency updates:

* [`android/Gemfile`](diffhunk://#diff-61751fb38ef24d7c31ebf37a4397c15f2b3ba2f1c34b6bdade8c25a6b46ae7e5R5-R6): Added `fastlane-plugin-sentry` to include the Sentry plugin for Fastlane.
* [`android/fastlane/Pluginfile`](diffhunk://#diff-a81c8825b084bcc8ff21eea41fd9a1ef8acfa3e2bbca041bf820d35e0e7f82fbR6-R7): Added `fastlane-plugin-sentry` to the Fastlane Pluginfile to enable its usage in Fastlane tasks.